### PR TITLE
Add colab link to README.md to run example notebooks online

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ Automated identification of text structures related to moralization.
 
 **_This project is currently under development!_**
 
+## Example notebooks
+
+- [DemoNotebook_statistics](notebooks/DemoNotebook_statistics.ipynb) [![open in colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ssciwr/moralization/blob/main/notebooks/DemoNotebook_statistics.ipynb)
+
 Based on an annotated corpus, the automatic classification of moralization constructs in written text will be investigated.
 
 The ability to identify different categories will be investigated:

--- a/notebooks/DemoNotebook_statistics.ipynb
+++ b/notebooks/DemoNotebook_statistics.ipynb
@@ -16,6 +16,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Please ignore this cell: extra install steps that are only executed when running the notebook on Google Colab\n",
+    "# flake8-noqa-cell\n",
+    "import os\n",
+    "if 'google.colab' in str(get_ipython()) and not os.path.isdir('Test_Data'):\n",
+    "    # we're running on colab and we haven't already downloaded the test data\n",
+    "    # first install pinned version of setuptools (latest version doesn't seem to work with this package on colab)\n",
+    "    !pip install setuptools==61 -qqq\n",
+    "    # install the moralization package\n",
+    "    !pip install git+https://github.com/ssciwr/moralization.git -qqq\n",
+    "    # download test data sets\n",
+    "    !wget https://github.com/ssciwr/moralization/archive/refs/heads/test_data.zip -q\n",
+    "    !unzip -qq test_data.zip && mv -f moralization-test_data/*_Data . && rm -rf moralization-test_data test_data.zip"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import moralization as mn\n",
     "\n",
     "# for plotting\n",
@@ -36,7 +56,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_dict = mn.InputOutput.get_input_dir(\"../data/Test_Data/XMI_11\")"
+    "data_dict = mn.InputOutput.get_input_dir(\"Test_Data/XMI_11\")"
    ]
   },
   {


### PR DESCRIPTION
- add a cell to demo notebook that only executes on colab
  - installs pinned version of setuptools (latest setuptools doesn't work with moralization/colab, maybe due to them running python 3.7?)
  - installs moralization
  - downloads test data
